### PR TITLE
Remove Dotenv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 
 .git
 .dockerignore
-/config/master.key
+
 /node_modules/
 /vendor/bundle/
 /tmp/

--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+RAILS_ENV=development
+DATABASE_HOST=postgres
+DATABASE_NAME=portfolio_development
+DATABASE_USERNAME=portfolio
+DATABASE_PASSWORD=test_db_password
+CACHE_URL=redis://redis:6379/0
+JOB_WORKER_URL=redis://redis:6379/0

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
-.env*
 node_modules
 gcs.json

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
-gem 'dotenv-rails', '~> 2.1', '>= 2.1.1'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,10 +98,6 @@ GEM
       warden (~> 1.2.3)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
-    dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
     erubi (1.12.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
@@ -335,7 +331,6 @@ DEPENDENCIES
   capybara
   debug
   devise (~> 4.9)
-  dotenv-rails (~> 2.1, >= 2.1.1)
   google-cloud-storage (~> 1.31, >= 1.31.1)
   image_processing (~> 1.2)
   importmap-rails (~> 1.2)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,11 +1,20 @@
 development:
-  url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_development?') %>
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
+  database: <%= ENV["DATABASE_NAME"] %>
+  username: <%= ENV["DATABASE_USERNAME"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
+  host: "<%= ENV["DATABASE_HOST"] %>"
 
-test:
-  url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_test?') %>
+  # url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_development?') %>
 
-staging:
-  url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_staging?') %>
+# test:
+#   url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_test?') %>
+
+# staging:
+#   url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_staging?') %>
 
 production:
   adapter: postgresql

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,27 +1,17 @@
-development:
+postgresql: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
   database: <%= ENV["DATABASE_NAME"] %>
   username: <%= ENV["DATABASE_USERNAME"] %>
+
+development:
+  <<: *default
   password: <%= ENV["DATABASE_PASSWORD"] %>
   host: "<%= ENV["DATABASE_HOST"] %>"
 
-  # url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_development?') %>
-
-# test:
-#   url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_test?') %>
-
-# staging:
-#   url: <%= ENV.fetch("DATABASE_URL","?").gsub('?', '_staging?') %>
-
 production:
-  adapter: postgresql
-  encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-  database: <%= ENV["DATABASE_NAME"] %>
-  username: <%= ENV["DATABASE_USERNAME"] %>
+  <<: *default
   password: <%= Rails.application.credentials.fetch(:gcp,{}).fetch(:db_password,"") %>
   host: "<%= ENV.fetch("DATABASE_SOCKET_DIR") { '/cloudsql' } %>/<%= ENV["CLOUD_SQL_CONNECTION_NAME"] %>"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,3 @@
-puts ENV.inspect
 sidekiq_config = { url: ENV['JOB_WORKER_URL'] }
 
 Sidekiq.configure_server do |config|

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,4 @@
+puts ENV.inspect
 sidekiq_config = { url: ENV['JOB_WORKER_URL'] }
 
 Sidekiq.configure_server do |config|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,6 @@ Rails.application.routes.draw do
   resources :posts
   resources :projects, only: [:index]
   devise_for :admins, controllers: { registrations: "registrations"}
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  
   root 'application#home'
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,30 +11,3 @@ google:
   project: <%= ENV["PROJECT_ID"] %>
   bucket: <%= ENV["STORAGE_BUCKET_NAME"] %>
   credentials: <%= ENV["STORAGE_CREDENTIALS"] %>
-
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name-<%= Rails.env %>
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,7 +1,5 @@
 # Heavily inspired by GitLab:
 # https://github.com/gitlabhq/gitlabhq/blob/master/config/unicorn.rb.example
-require 'dotenv'
-Dotenv.load ".env"
 
 worker_processes 1
 listen 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     build:
       context: .
     volumes:
-      - .:/opt/app
+      - .:/app
     links:
       - postgres
       - redis
@@ -31,7 +31,11 @@ services:
       - '8010:8010'
     environment:
       - RAILS_ENV=development
-      - DATABASE_URL=postgresql://portfolio:test_db_password@postgres:5432/portfolio?encoding=utf8&pool=5&timeout=5000\
+      # - DATABASE_URL=postgresql://portfolio:test_db_password@postgres:5432/portfolio?encoding=utf8&pool=5&timeout=5000
+      - DATABASE_HOST=postgres
+      - DATABASE_NAME=portfolio_development
+      - DATABASE_USERNAME=portfolio
+      - DATABASE_PASSWORD=test_db_password
       - CACHE_URL=redis://redis:6379/0
       - JOB_WORKER_URL=redis://redis:6379/0
 
@@ -42,6 +46,8 @@ services:
     links:
       - postgres
       - redis
+    environment:
+      - JOB_WORKER_URL=redis://redis:6379/0
 
   nginx:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,15 +29,8 @@ services:
       - redis
     ports:
       - '8010:8010'
-    environment:
-      - RAILS_ENV=development
-      # - DATABASE_URL=postgresql://portfolio:test_db_password@postgres:5432/portfolio?encoding=utf8&pool=5&timeout=5000
-      - DATABASE_HOST=postgres
-      - DATABASE_NAME=portfolio_development
-      - DATABASE_USERNAME=portfolio
-      - DATABASE_PASSWORD=test_db_password
-      - CACHE_URL=redis://redis:6379/0
-      - JOB_WORKER_URL=redis://redis:6379/0
+    env_file:
+      - .env
 
   sidekiq:
     build:
@@ -46,8 +39,8 @@ services:
     links:
       - postgres
       - redis
-    environment:
-      - JOB_WORKER_URL=redis://redis:6379/0
+    env_file:
+      - .env
 
   nginx:
     build:


### PR DESCRIPTION
Closes #3 

refinangles development environment to work without dotenv gem. sets up docker compose stuff properly.

Adds a .env file that docker-compose uses (but not rails specifically, for development.)