### PR TITLE
Fix load order

### DIFF
--- a/app/javascript/controllers/posts.js
+++ b/app/javascript/controllers/posts.js
@@ -1,31 +1,36 @@
 import Rails from "@rails/ujs"
 import UIkit from "uikit"
 
+const BOTTOM = "#bottom-of-page"
+const POST_CONTAINER = "#post-index"
+
 export default {
     index: _ => {
         var oldest = new Date(Date.now()).toISOString()
-        UIkit.util.on('#post-index', 'inview', event => {
+        UIkit.util.on(POST_CONTAINER, 'inview', event => {
             Rails.$("title")[0].innerHTML = event.target.dataset.title
         });
-        UIkit.util.on('#bottom-of-page', 'inview', _ => {
+        UIkit.util.on(BOTTOM, 'inview', _ => {
             Rails.ajax({
                 url: "/posts.json",
                 data: new URLSearchParams({'before': oldest}).toString(),
                 type: "get",
                 success: data => { 
                     console.log(data)
-                    Rails.$("#post-index")[0].innerHTML += data.html
+                    Rails.$(POST_CONTAINER)[0].innerHTML += data.html
                     oldest = data.oldest
                     if(data.count != data.limit) {
-                        Rails.$("#bottom-of-page")[0].remove()
+                        Rails.$(BOTTOM)[0].remove()
                     }
                 },
                 error: err => {
                     console.error(err)
-                    Rails.$("#bottom-of-page")[0].remove()
+                    Rails.$(BOTTOM)[0].remove()
                     Rails.$("#fetch-error")[0].className = ""
                 }
             })
         });
+
+        UIkit.scrollspy(Rails.$(BOTTOM)[0])
     }
 }

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,5 +1,5 @@
 #post-index
-#bottom-of-page.uk-flex.uk-flex-center uk-scrollspy="repeat: true" uk-spinner="ratio:3"
+#bottom-of-page.uk-flex.uk-flex-center uk-spinner="ratio:3"
 #fetch-error.uk-hidden
     h1 Something went wrong!
     p If you're seeing this, we couldn't fetch the latest posts. We'll send someone down the pipes to figure it out.


### PR DESCRIPTION
Closes #28

Initialized scrollspy for the bottom of the page in javascript rather than html, removing the race condition this logic relied on before.